### PR TITLE
feat(rhoso-apps): add ignoreDifferences support to Application template

### DIFF
--- a/charts/rhoso-apps/templates/_helpers.tpl
+++ b/charts/rhoso-apps/templates/_helpers.tpl
@@ -87,6 +87,18 @@ Pass dict with key "app" (per-application values map).
 {{- end }}
 
 {{/*
+Optional spec.ignoreDifferences for the Argo CD Application.
+Pass dict with key "app" (per-application values map). Omitted if unset or empty.
+*/}}
+{{- define "rhoso-apps.ignoreDifferences" -}}
+{{- $app := .app -}}
+{{- if and $app.ignoreDifferences (not (empty $app.ignoreDifferences)) }}
+  ignoreDifferences:
+{{ toYaml $app.ignoreDifferences | indent 4 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Argo CD Application metadata.finalizers (resources finalizer: background vs foreground).
 Omitted finalizers default to background deletion.
 Pass dict with key "app" (per-application values map).

--- a/charts/rhoso-apps/templates/application.yaml
+++ b/charts/rhoso-apps/templates/application.yaml
@@ -20,5 +20,6 @@ spec:
   destination:
     server: {{ include "rhoso-apps.destinationServer" $ }}
 {{ include "rhoso-apps.syncPolicySpec" (dict "app" $app) }}
+{{ include "rhoso-apps.ignoreDifferences" (dict "app" $app) }}
 {{- end }}
 {{- end }}

--- a/charts/rhoso-apps/tests/application_test.yaml
+++ b/charts/rhoso-apps/tests/application_test.yaml
@@ -201,6 +201,72 @@ tests:
       - failedTemplate:
           errorPattern: destinationServer
 
+  - it: omits spec.ignoreDifferences when not set in values
+    values:
+      - ../values.yaml
+    documentSelector:
+      path: metadata.name
+      value: operator-dependencies
+    asserts:
+      - notExists:
+          path: spec.ignoreDifferences
+
+  - it: renders spec.ignoreDifferences when set
+    set:
+      applicationNamespace: openshift-gitops
+      destinationServer: https://kubernetes.default.svc
+      applications:
+        ignore-diff-test:
+          enabled: true
+          repoURL: https://github.com/example/repo
+          path: "."
+          targetRevision: main
+          syncOptions:
+            - RespectIgnoreDifferences=true
+          ignoreDifferences:
+            - group: core.openstack.org
+              kind: OpenStackControlPlane
+              jsonPointers:
+                - /spec/tls
+                - /spec/watcher
+    documentSelector:
+      path: metadata.name
+      value: ignore-diff-test
+    asserts:
+      - equal:
+          path: spec.ignoreDifferences[0].group
+          value: core.openstack.org
+      - equal:
+          path: spec.ignoreDifferences[0].kind
+          value: OpenStackControlPlane
+      - equal:
+          path: spec.ignoreDifferences[0].jsonPointers[0]
+          value: /spec/tls
+
+  - it: renders spec.ignoreDifferences with jqPathExpressions
+    set:
+      applicationNamespace: openshift-gitops
+      destinationServer: https://kubernetes.default.svc
+      applications:
+        jq-diff-test:
+          enabled: true
+          repoURL: https://github.com/example/repo
+          path: "."
+          targetRevision: main
+          syncOptions: []
+          ignoreDifferences:
+            - group: dataplane.openstack.org
+              kind: OpenStackDataPlaneNodeSet
+              jqPathExpressions:
+                - '.spec.preProvisioned | select(. == false or . == "false")'
+    documentSelector:
+      path: metadata.name
+      value: jq-diff-test
+    asserts:
+      - equal:
+          path: spec.ignoreDifferences[0].jqPathExpressions[0]
+          value: '.spec.preProvisioned | select(. == false or . == "false")'
+
   - it: fails values schema when finalizer is not allowed
     set:
       applicationNamespace: openshift-gitops

--- a/charts/rhoso-apps/values.schema.json
+++ b/charts/rhoso-apps/values.schema.json
@@ -96,6 +96,14 @@
           "description": "Optional Argo CD spec.source.kustomize overrides (see Argo CD Kustomize user guide).",
           "additionalProperties": true
         },
+        "ignoreDifferences": {
+          "type": "array",
+          "description": "Optional spec.ignoreDifferences for the Argo CD Application. Each item follows the Argo CD ResourceIgnoreDifferences schema.",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
         "finalizers": {
           "type": "array",
           "description": "Argo CD Application metadata.finalizers (resources finalizer). Omit to use chart default (background).",
@@ -107,6 +115,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "resources-finalizer.argocd.argoproj.io",
               "resources-finalizer.argocd.argoproj.io/background",
               "resources-finalizer.argocd.argoproj.io/foreground"
             ]


### PR DESCRIPTION
Add optional spec.ignoreDifferences to the rendered ArgoCD Application resources. This is needed for deployments where operator-mutated fields (e.g. OpenStackControlPlane /spec/tls, BareMetalHost /status) cause perpetual OutOfSync without ignoreDifferences.

Changes:
- values.schema.json: add ignoreDifferences array (items: object with additionalProperties) to the application definition; also allow the base finalizer string (without /background or /foreground suffix)
- _helpers.tpl: add rhoso-apps.ignoreDifferences helper
- application.yaml: render ignoreDifferences when present
- application_test.yaml: add 3 tests (omitted when unset, jsonPointers, jqPathExpressions)