### PR TITLE
fix(eso): remove argocd/annotations from example/dependencies base kustomization

### DIFF
--- a/components/secrets/external-secrets-operator/redhat/externalsecretsconfig.yaml
+++ b/components/secrets/external-secrets-operator/redhat/externalsecretsconfig.yaml
@@ -1,8 +1,9 @@
 ---
 # ExternalSecretsConfig is required by the Red Hat External Secrets Operator (RHESO)
 # to deploy the actual ESO controller pods (external-secrets, webhook, cert-controller).
-# Sync wave and SkipDryRunOnMissingResource are managed centrally via
-# components/argocd/annotations/kustomization.yaml.
+# Sync wave and SkipDryRunOnMissingResource are managed via the argocd/annotations
+# component patch, which must be included by the consumer in the ArgoCD Application
+# spec (spec.source.kustomize.components) — not in the base kustomization.
 apiVersion: operator.openshift.io/v1alpha1
 kind: ExternalSecretsConfig
 metadata:

--- a/example/dependencies/kustomization.yaml
+++ b/example/dependencies/kustomization.yaml
@@ -6,4 +6,11 @@ components:
   - https://github.com/openstack-k8s-operators/architecture/lib/olm-deps?ref=7da5f2e1dc2bfce99e269b0017783679ca405d8c
   - https://github.com/openstack-k8s-operators/architecture/lib/metallb?ref=7da5f2e1dc2bfce99e269b0017783679ca405d8c
   - https://github.com/openstack-k8s-operators/architecture/lib/nmstate?ref=7da5f2e1dc2bfce99e269b0017783679ca405d8c
-  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.0
+  # The argocd/annotations component is intentionally NOT included here.
+  # It must be added by the consumer via the ArgoCD Application spec
+  # (spec.source.kustomize.components). Including it here AND in the app spec
+  # causes kustomize to deduplicate it — the component runs only once during
+  # base processing, before any app-level components (e.g. ESO) add their
+  # resources. Patches in the annotations component that target those
+  # app-level resources become no-ops, breaking sync-wave ordering and
+  # SkipDryRunOnMissingResource behaviour for CRs like ExternalSecretsConfig.


### PR DESCRIPTION
    fix(eso): remove argocd/annotations from example/dependencies base kustomization
    
    When the argocd/annotations component is included in both the base
    kustomization (example/dependencies) and the ArgoCD Application spec
    (spec.source.kustomize.components), kustomize deduplicates it and only
    processes it once — during base processing — before any app-level
    components (e.g. ESO) add their resources. Patches targeting those
    app-level resources become no-ops, causing SkipDryRunOnMissingResource
    and sync-wave annotations to never be applied to ExternalSecretsConfig.
    
    Without SkipDryRunOnMissingResource=true, ArgoCD fails the pre-sync
    dry-run for ExternalSecretsConfig because the ESO CRD does not exist
    yet (the ESO operator subscription is in sync-wave -10). The entire
    sync is aborted before any wave runs.
    
    Fix: remove the argocd/annotations component from the base kustomization.
    Consumers using the rhoso-apps helm chart already inject it via
    spec.source.kustomize.components, where it runs after all app-level
    components and patches apply correctly. A comment is added to prevent
    re-introduction of the component in the base.
    
    Also revert the externalsecretsconfig.yaml comment to reflect the
    correct design: annotations are applied via the component patch,
    not embedded directly in the resource.
    