### PR TITLE
chore(release): bump version references to v0.3.1

### DIFF
--- a/applications/external-secrets-operator-redhat.yaml
+++ b/applications/external-secrets-operator-redhat.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     kustomize:
       components:
-        - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.0
+        - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.1
     path: resources/external-secrets-operator/redhat
     repoURL: https://github.com/openstack-k8s-operators/gitops.git
     targetRevision: HEAD

--- a/applications/external-secrets-operator.yaml
+++ b/applications/external-secrets-operator.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     kustomize:
       components:
-        - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.0
+        - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.1
     path: resources/external-secrets-operator
     repoURL: https://github.com/openstack-k8s-operators/gitops.git
     targetRevision: HEAD

--- a/applications/vault-secrets-operator.yaml
+++ b/applications/vault-secrets-operator.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     kustomize:
       components:
-        - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.0
+        - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.1
     path: resources/vault-secrets-operator
     repoURL: https://github.com/openstack-k8s-operators/gitops.git
     targetRevision: HEAD

--- a/charts/rhoso-apps/Chart.yaml
+++ b/charts/rhoso-apps/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rhoso-apps/README.md
+++ b/charts/rhoso-apps/README.md
@@ -364,7 +364,7 @@ applications:
   operator-dependencies:
     kustomize:
       components:
-        - "https://github.com/openstack-k8s-operators/gitops/components/secrets/vault-secrets-operator?ref=v0.3.0"
+        - "https://github.com/openstack-k8s-operators/gitops/components/secrets/vault-secrets-operator?ref=v0.3.1"
 ```
 
 `openstack-secrets` excerpt (Vault Secrets Operator style patch; adjust for

--- a/charts/rhoso-apps/tests/application_test.yaml
+++ b/charts/rhoso-apps/tests/application_test.yaml
@@ -41,7 +41,7 @@ tests:
           value: example/controlplane
       - equal:
           path: spec.source.targetRevision
-          value: v0.3.0
+          value: v0.3.1
       - equal:
           path: spec.destination.server
           value: https://kubernetes.default.svc

--- a/charts/rhoso-apps/values.yaml
+++ b/charts/rhoso-apps/values.yaml
@@ -14,7 +14,7 @@ applications:
     syncOptions:
       - Prune=true
     syncWave: "-20"
-    targetRevision: v0.3.0
+    targetRevision: v0.3.1
   # Deploy openstack-operator.
   # This covers "Deploying RHOSO - chapter 1"
   # https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html/deploying_red_hat_openstack_services_on_openshift/assembly_installing-and-preparing-the-openstack-operator
@@ -25,7 +25,7 @@ applications:
     syncOptions:
       - Prune=true
     syncWave: "-20"
-    targetRevision: v0.3.0
+    targetRevision: v0.3.1
   # Create the main OpenStack Custom Resource.
   # This covers "Deploying RHOSO - chapter 1"
   # https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html/deploying_red_hat_openstack_services_on_openshift/assembly_installing-and-preparing-the-openstack-operator
@@ -36,7 +36,7 @@ applications:
     syncOptions:
       - Prune=true
     syncWave: "-15"
-    targetRevision: v0.3.0
+    targetRevision: v0.3.1
   # Create cluster secrets by syncing from the secure backend (placeholder path).
   # Runs after operator-dependencies provides vault-secrets-operator or external-secrets-operator.
   # This covers "Deploying RHOSO - chapter 2.3"
@@ -48,7 +48,7 @@ applications:
     syncOptions:
       - Prune=true
     syncWave: "-10"
-    targetRevision: v0.3.0
+    targetRevision: v0.3.1
   # Create underlying networks for controlplane and dataplane.
   # Covers "Deploying RHOSO - chapter 3"
   # https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html/deploying_red_hat_openstack_services_on_openshift/assembly_preparing-rhoso-networks_preparing
@@ -59,7 +59,7 @@ applications:
     syncOptions:
       - Prune=true
     syncWave: "0"
-    targetRevision: v0.3.0
+    targetRevision: v0.3.1
   # Deploy and configure OpenStackControlPlane resource.
   # Covers "Deploying RHOSO - chapter 4"
   # https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html/deploying_red_hat_openstack_services_on_openshift/assembly_creating-the-control-plane
@@ -72,7 +72,7 @@ applications:
     syncOptions:
       - Prune=true
     syncWave: "10"
-    targetRevision: v0.3.0
+    targetRevision: v0.3.1
   # Deploy and configure OpenStackDataPlaneNodeSet and OpenStackDataPlaneDeployment resources.
   # Covers "Deploying RHOSO - chapter 5"
   # https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html/deploying_red_hat_openstack_services_on_openshift/assembly_creating-the-data-plane
@@ -83,4 +83,4 @@ applications:
     syncOptions:
       - Prune=true
     syncWave: "20"
-    targetRevision: v0.3.0
+    targetRevision: v0.3.1

--- a/components/secrets/README.md
+++ b/components/secrets/README.md
@@ -15,7 +15,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources: []
 components:
-  - https://github.com/openstack-k8s-operators/gitops/components/secrets/vault-secrets-operator?ref=v0.3.0
+  - https://github.com/openstack-k8s-operators/gitops/components/secrets/vault-secrets-operator?ref=v0.3.1
 ```
 
 Example including the Red Hat ESO overlay as a resource:
@@ -24,5 +24,5 @@ Example including the Red Hat ESO overlay as a resource:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/openstack-k8s-operators/gitops/components/secrets/external-secrets-operator/redhat?ref=v0.3.0
+  - https://github.com/openstack-k8s-operators/gitops/components/secrets/external-secrets-operator/redhat?ref=v0.3.1
 ```

--- a/components/utilities/approve-installplan/README.md
+++ b/components/utilities/approve-installplan/README.md
@@ -17,7 +17,7 @@ runs first, the Subscription sync-wave patch will not apply.
 components:
   - pin-version
   - https://github.com/openstack-k8s-operators/architecture/lib/olm-openstack-subscriptions/overlays/default?ref=COMMIT_SHA
-  - https://github.com/openstack-k8s-operators/gitops/components/utilities/approve-installplan?ref=v0.3.0
+  - https://github.com/openstack-k8s-operators/gitops/components/utilities/approve-installplan?ref=v0.3.1
 ```
 
 Images: `registry.redhat.io/openshift4/ose-tools-rhel9:latest` (Job).

--- a/example/openstack-controlplane/kustomization.yaml
+++ b/example/openstack-controlplane/kustomization.yaml
@@ -4,9 +4,9 @@ kind: Kustomization
 
 components:
   # Remote refs (for CI/ArgoCD):
-  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.0
-  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/controlplane/controlplane?ref=v0.3.0
-  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/controlplane/services/watcher?ref=v0.3.0
+  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.1
+  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/controlplane/controlplane?ref=v0.3.1
+  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/controlplane/services/watcher?ref=v0.3.1
   # Local paths (for "kustomize build" testing):
   # - ../../components/argocd/annotations
   # - ../../components/rhoso/controlplane/controlplane

--- a/example/openstack-dataplane/kustomization.yaml
+++ b/example/openstack-dataplane/kustomization.yaml
@@ -4,8 +4,8 @@ kind: Kustomization
 
 components:
   # Remote refs (for CI/ArgoCD):
-  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.0
-  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/dataplane?ref=v0.3.0
+  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.1
+  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/dataplane?ref=v0.3.1
   # Local paths (for "kustomize build" testing):
   # - ../../components/argocd/annotations
   # - ../../components/rhoso/dataplane

--- a/example/openstack-networks/kustomization.yaml
+++ b/example/openstack-networks/kustomization.yaml
@@ -4,8 +4,8 @@ kind: Kustomization
 
 components:
   # Remote refs (for CI/ArgoCD):
-  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.0
-  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/controlplane/networking?ref=v0.3.0
+  - https://github.com/openstack-k8s-operators/gitops/components/argocd/annotations?ref=v0.3.1
+  - https://github.com/openstack-k8s-operators/gitops/components/rhoso/controlplane/networking?ref=v0.3.1
   # Local paths (for "kustomize build" testing):
   # - ../../components/argocd/annotations
   # - ../../components/rhoso/controlplane/networking

--- a/example/openstack-operator/README.md
+++ b/example/openstack-operator/README.md
@@ -21,7 +21,7 @@ See Red Hat documentation:
 | `catalog/values.yaml` | `ConfigMap` `olm-values` (channel, `redhat-operators`, index image, Manual approval) |
 | `pin-version/` | Adds `data.openstack-operator-version` for `spec.startingCSV` |
 | Remote component | `architecture` `olm-openstack-subscriptions/overlays/default` (pinned git ref in `kustomization.yaml`) |
-| [approve-installplan](https://github.com/openstack-k8s-operators/gitops/tree/v0.3.0/components/utilities/approve-installplan) (`?ref=v0.3.0`) | Shared utility: RBAC, InstallPlan approval `Job`, Subscription sync-wave |
+| [approve-installplan](https://github.com/openstack-k8s-operators/gitops/tree/v0.3.1/components/utilities/approve-installplan) (`?ref=v0.3.1`) | Shared utility: RBAC, InstallPlan approval `Job`, Subscription sync-wave |
 
 Component order in `kustomization.yaml` matters: the version pin runs before the remote OLM
 component; the approval `Component` runs after it so the Subscription exists when the sync-wave patch

--- a/example/openstack-operator/kustomization.yaml
+++ b/example/openstack-operator/kustomization.yaml
@@ -11,6 +11,6 @@ components:
   - pin-version
   - https://github.com/openstack-k8s-operators/architecture/lib/olm-openstack-subscriptions/overlays/default?ref=7da5f2e1dc2bfce99e269b0017783679ca405d8c
   # TODO: replace the local path with a git HTTPS URI, e.g.
-  # https://github.com/openstack-k8s-operators/gitops/components/utilities/approve-installplan?ref=v0.3.0
+  # https://github.com/openstack-k8s-operators/gitops/components/utilities/approve-installplan?ref=v0.3.1
   # once that tag includes this component (same pattern as other example overlays).
   - ../../components/utilities/approve-installplan


### PR DESCRIPTION
Update all ?ref=, targetRevision, Chart.yaml version, and test assertions from v0.3.0 to v0.3.1.