### PR TITLE
feat(security): enhance supply-chain security with OpenSSF Scorecard and SBOM

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -100,3 +100,21 @@ jobs:
       # Produces rhoso-apps-*.tgz; publishing is TODO until release workflow exists (see file header).
       - name: Helm package
         run: helm package .
+
+      # Generate SBOM for supply-chain transparency (SLSA provenance L1, OpenSSF Scorecard SBOM check).
+      # SPDX format is industry standard and SLSA-compatible. Artifact will be attached to GitHub
+      # Releases once the release process is defined (see file header TODO).
+      - name: Generate SBOM for Helm chart
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          path: charts/rhoso-apps
+          artifact-name: rhoso-apps-sbom.spdx.json
+          output-file: rhoso-apps-sbom.spdx.json
+          format: spdx-json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        with:
+          name: rhoso-apps-sbom
+          path: rhoso-apps-sbom.spdx.json
+          retention-days: 90

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+---
+name: OpenSSF Scorecard
+permissions: read-all
+
+on:  # yamllint disable-line rule:truthy
+  branch_protection_rule:
+  schedule:
+    # Weekly on Mondays at 9:17 AM UTC (avoiding :00/:30 for API load distribution)
+    - cron: '17 9 * * 1'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # Upload SARIF results to GitHub Security tab
+      id-token: write         # Publish results to OpenSSF API
+      contents: read          # Read repository contents
+      actions: read           # Read workflow configurations
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results to Security tab
+        uses: github/codeql-action/upload-sarif@411c4c9a36b3fca4d674f06b6396b2c6d23522c6  # v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload Scorecard results as artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 30

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+  - cjeanner
+  - pinikomarov
+  - holser
+
+reviewers:
+  - cjeanner
+  - pinikomarov
+  - holser

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,89 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The openstack-k8s-operators project welcomes responsible disclosure of security vulnerabilities. Security is a top priority for this project and the Red Hat OpenStack Services on OpenShift (RHOSO) ecosystem.
+
+### How to Report
+
+**For Red Hat customers and partners:**
+- Report security vulnerabilities to Red Hat Product Security: https://access.redhat.com/security/team/contact/
+- Red Hat Product Security Incident Response Team (PSIRT) will coordinate with the project maintainers
+
+**For community contributors:**
+- **Do not** open public GitHub issues for security vulnerabilities
+- Email security concerns to: secalert@redhat.com
+- Include detailed steps to reproduce, impact assessment, and any proof-of-concept code if available
+
+### What to Expect
+
+- **Acknowledgment:** We will acknowledge receipt of your vulnerability report within 3 business days
+- **Investigation:** Our security team will investigate and validate the report
+- **Timeline:** We aim to provide an initial assessment within 7 business days
+- **Resolution:** Critical vulnerabilities will be prioritized for immediate patching
+- **Disclosure:** We follow coordinated disclosure practices and will work with you on an appropriate disclosure timeline
+
+### Security Considerations for This Repository
+
+This repository contains GitOps configuration manifests for deploying Red Hat OpenStack Services on OpenShift using ArgoCD. It does not ship application source code but manages:
+
+- ArgoCD/OpenShift-GitOps bootstrap configurations (primarily for dev/lab/testing environments)
+- Kustomize overlays for RHOSO control-plane and data-plane
+- Helm charts (rhoso-apps)
+- Kubernetes RBAC policies
+- ArgoCD hook Jobs and utility manifests
+
+**Key Security Concerns:**
+- Overly permissive RBAC configurations
+- Insecure container image references or workload configurations
+- Supply-chain vulnerabilities in GitHub Actions, container images, or dependencies
+- GitOps trust boundary violations (AppProjects, targetRevision, syncPolicy)
+- Secrets handling and External Secrets Operator configurations
+
+See our [ArgoCD Deployment Security Hardening Guide](openshift-gitops.deploy/SECURITY.md) for deployment-specific security controls and best practices.
+
+## Supported Versions
+
+We provide security updates for:
+
+| Version/Branch | Supported          |
+| -------------- | ------------------ |
+| main (latest)  | :white_check_mark: |
+| Tagged releases| :x: (no backports) |
+| Feature branches| :x: (use at own risk) |
+
+Security patches are applied to the `main` branch only. We do not backport security fixes to older tagged releases. Users should use the latest available tag and update to newer tags as they are released to receive security fixes.
+
+## Security Update Policy
+
+- **Critical vulnerabilities** (CVSS >= 9.0): Patched within 48 hours of validation
+- **High severity** (CVSS 7.0-8.9): Patched within 7 days
+- **Medium severity** (CVSS 4.0-6.9): Patched in next regular release cycle
+- **Low severity** (CVSS < 4.0): Addressed in scheduled maintenance updates
+
+## Supply-Chain Security
+
+This repository implements automated supply-chain security controls:
+
+- **Dependabot:** Automated dependency updates for GitHub Actions, Python packages, and container images
+- **OpenSSF Scorecard:** Automated security scoring and best-practice validation
+- **SBOM Generation:** Software Bill of Materials for Helm charts in SPDX format
+- **SHA-pinned Actions:** GitHub Actions pinned to commit SHAs for integrity
+- **Image Digest Pinning:** Container images pinned to SHA256 digests where possible
+
+See our OpenSSF Scorecard results: https://securityscorecards.dev/viewer/?uri=github.com/openstack-k8s-operators/gitops
+
+## Additional Resources
+
+- [Red Hat Product Security Center](https://access.redhat.com/security/)
+- [OpenStack Security Advisories](https://security.openstack.org/)
+- [Kubernetes Security Best Practices](https://kubernetes.io/docs/concepts/security/)
+- [ArgoCD Security Hardening](https://argo-cd.readthedocs.io/en/stable/operator-manual/security/)
+
+## Acknowledgments
+
+We appreciate security researchers and the community for responsible disclosure. Contributors who report valid security vulnerabilities will be acknowledged in our security advisories (unless they prefer to remain anonymous).
+
+---
+
+**Last Updated:** 2026-07-08


### PR DESCRIPTION
Add comprehensive supply-chain security controls to improve project security posture and automated dependency monitoring.

Changes:
- Add SECURITY.md with vulnerability reporting policy and Red Hat PSIRT disclosure process
- Add OpenSSF Scorecard workflow for automated security scoring published to GitHub Security tab and securityscorecards.dev API
- Generate SPDX SBOM for Helm charts to satisfy SLSA provenance requirements
- Add OWNERS file to document project maintainers and reviewers
- Pin all new GitHub Actions to commit SHAs for supply-chain integrity

The Scorecard workflow runs weekly and on branch protection changes, providing continuous visibility into security best practices. SBOM artifacts are uploaded with 90-day retention and will be attached to future GitHub Releases.