### PR TITLE
docs(security): add opt-in Manual installPlanApproval overlays (FIND-010)

### DIFF
--- a/components/secrets/external-secrets-operator/manual-approval/kustomization.yaml
+++ b/components/secrets/external-secrets-operator/manual-approval/kustomization.yaml
@@ -1,0 +1,44 @@
+---
+# Opt-in overlay: switch the ESO subscription to Manual installPlanApproval.
+#
+# Include this component AFTER the base ESO component (community or redhat)
+# to override installPlanApproval from Automatic to Manual and pin a
+# specific startingCSV.
+#
+# Manual approval means OLM will not install a new operator version until
+# an administrator (or automation) explicitly approves the InstallPlan.
+# This provides change-control over operator upgrades at the cost of
+# requiring an approval step on every new version.
+#
+# NOTE: When using Manual approval you must ensure InstallPlans are approved
+# before the operator can install or upgrade. Options:
+#   - Approve manually: oc patch installplan <name> -n <ns> --type merge
+#       -p '{"spec":{"approved":true}}'
+#   - Or implement an automated approval Job (see the pattern in
+#     components/utilities/approve-installplan for the openstack-operator).
+#
+# Usage in a consumer kustomization:
+#   components:
+#     - https://github.com/openstack-k8s-operators/gitops/components/secrets/external-secrets-operator/redhat?ref=<tag>
+#     - https://github.com/openstack-k8s-operators/gitops/components/secrets/external-secrets-operator/manual-approval?ref=<tag>
+#
+# Remember to update startingCSV to the version currently running in your
+# cluster before switching to Manual. Query with:
+#   oc get subscription openshift-external-secrets-operator -n external-secrets-operator \
+#     -o jsonpath='{.status.currentCSV}'
+
+# ---- EXAMPLE — uncomment and fill in before using ----
+#
+# apiVersion: kustomize.config.k8s.io/v1alpha1
+# kind: Component
+# patches:
+#   - target:
+#       kind: Subscription
+#       name: external-secrets-operator
+#     patch: |-
+#       - op: replace
+#         path: /spec/installPlanApproval
+#         value: Manual
+#       - op: add
+#         path: /spec/startingCSV
+#         value: openshift-external-secrets-operator.v<VERSION>   # replace with current CSV

--- a/components/secrets/vault-secrets-operator/manual-approval/kustomization.yaml
+++ b/components/secrets/vault-secrets-operator/manual-approval/kustomization.yaml
@@ -1,0 +1,33 @@
+---
+# Opt-in overlay: switch the VSO subscription to Manual installPlanApproval.
+#
+# Include this component AFTER the base VSO component to override
+# installPlanApproval from Automatic to Manual and pin a specific startingCSV.
+#
+# See components/secrets/external-secrets-operator/manual-approval/kustomization.yaml
+# for full usage notes and approval options.
+#
+# Query your currently installed CSV:
+#   oc get subscription vault-secrets-operator -n openshift-operators \
+#     -o jsonpath='{.status.currentCSV}'
+#
+# Usage in a consumer kustomization:
+#   components:
+#     - https://github.com/openstack-k8s-operators/gitops/components/secrets/vault-secrets-operator?ref=<tag>
+#     - https://github.com/openstack-k8s-operators/gitops/components/secrets/vault-secrets-operator/manual-approval?ref=<tag>
+
+# ---- EXAMPLE — uncomment and fill in before using ----
+#
+# apiVersion: kustomize.config.k8s.io/v1alpha1
+# kind: Component
+# patches:
+#   - target:
+#       kind: Subscription
+#       name: vault-secrets-operator
+#     patch: |-
+#       - op: replace
+#         path: /spec/installPlanApproval
+#         value: Manual
+#       - op: add
+#         path: /spec/startingCSV
+#         value: vault-secrets-operator.v<VERSION>   # replace with current CSV


### PR DESCRIPTION
## Summary

Addresses OSPRH-32422 / FIND-010: OLM Subscriptions use Automatic install-plan approval and floating channel without startingCSV.

The shipped subscriptions for ESO, VSO, and openshift-gitops-operator use `installPlanApproval: Automatic`. This is intentional — it keeps the deployment simple and avoids the operational overhead of an in-cluster Job that must approve every new InstallPlan.

Rather than switching the base manifests to Manual (which requires hacky in-cluster Jobs for each component and doesn't scale well when multiple plans land simultaneously), this PR provides **opt-in overlay components** for deployments that need stricter change-control:

- `components/secrets/external-secrets-operator/manual-approval/` — switches ESO to Manual + pins `startingCSV`
- `components/secrets/vault-secrets-operator/manual-approval/` — switches VSO to Manual + pins `startingCSV`

Consumers include the overlay after the base component and update `startingCSV` when they want to advance the operator version. Administrators then approve the resulting InstallPlan (manually or via automation) before OLM installs the new CSV.

The `openshift-gitops-operator` subscription is excluded: it is applied by the Ansible bootstrap before ArgoCD exists, so no in-cluster Job can approve a Manual InstallPlan at that stage. Version gating is handled via `openshift_gitops_deploy_git_ref` in the automation repo.

## Test plan

- [ ] `kustomize build` with the overlay applied shows `installPlanApproval: Manual` and `startingCSV` on the subscription
- [ ] Without the overlay, subscriptions remain `Automatic` (no behaviour change for existing consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)