### PR TITLE
docs(security): note shared SA privilege on Jobs (OSPRH-32425 / FIND-…

### DIFF
--- a/components/argocd/hooks/postDelete/controlplane/controlplaneCleaning.yaml
+++ b/components/argocd/hooks/postDelete/controlplane/controlplaneCleaning.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   template:
     spec:
+      # NOTE (FIND-013 / OSPRH-32425): This post-delete hook runs as the shared ArgoCD
+      # SA which carries the full gitops-openstack ClusterRole. The hook is an example
+      # pattern for CI/lab environments; it only needs delete on openstackcontrolplanes
+      # in the openstack namespace. For production use, replace with a dedicated SA
+      # bound to a minimal Role scoped to that single verb/resource/namespace, and set
+      # automountServiceAccountToken: true only on the Job pod spec.
       serviceAccountName: openshift-gitops-argocd-application-controller
       restartPolicy: Never
       securityContext:

--- a/components/argocd/hooks/postDelete/dataplane/OpenStackDataPlaneService-deletion.yaml
+++ b/components/argocd/hooks/postDelete/dataplane/OpenStackDataPlaneService-deletion.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   template:
     spec:
+      # NOTE (FIND-013 / OSPRH-32425): This post-delete hook runs as the shared ArgoCD
+      # SA which carries the full gitops-openstack ClusterRole. The hook is an example
+      # pattern for CI/lab environments; it only needs delete on openstackdataplaneservices
+      # in the openstack namespace. For production use, replace with a dedicated SA
+      # bound to a minimal Role scoped to that single verb/resource/namespace, and set
+      # automountServiceAccountToken: true only on the Job pod spec.
       serviceAccountName: openshift-gitops-argocd-application-controller
       restartPolicy: Never
       securityContext:

--- a/components/argocd/hooks/postDelete/deploy-operators/observability-csv.yaml
+++ b/components/argocd/hooks/postDelete/deploy-operators/observability-csv.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   template:
     spec:
+      # NOTE (FIND-013 / OSPRH-32425): This post-delete hook runs as the shared ArgoCD
+      # SA which carries the full gitops-openstack ClusterRole. The hook is an example
+      # pattern for CI/lab environments; it only needs delete on ClusterServiceVersions
+      # in openshift-operators. For production use, replace with a dedicated SA bound
+      # to a minimal Role scoped to that single verb/resource/namespace, and set
+      # automountServiceAccountToken: true only on the Job pod spec.
       serviceAccountName: openshift-gitops-argocd-application-controller
       restartPolicy: Never
       securityContext:

--- a/components/utilities/approve-installplan/job.yaml
+++ b/components/utilities/approve-installplan/job.yaml
@@ -174,4 +174,13 @@ spec:
 
               log "Job completed successfully."
       restartPolicy: Never
+      # NOTE (FIND-013 / OSPRH-32425): This Job runs as the shared ArgoCD SA which
+      # carries the full gitops-openstack ClusterRole. The approve-installplan pattern
+      # is a CI/lab convenience to handle Manual installPlanApproval without human
+      # intervention; it is not intended for production environments. When OLM v2
+      # (ClusterExtension API) becomes standard, InstallPlan approval is replaced by
+      # version pinning in Git and this Job will no longer be needed. For production
+      # use, create a dedicated SA bound only to a Role granting get/list/patch on
+      # installplans in the target namespace, with automountServiceAccountToken: true
+      # only on the Job pod spec.
       serviceAccountName: openshift-gitops-argocd-application-controller


### PR DESCRIPTION
…013)

All four Job specs use openshift-gitops-argocd-application-controller, the shared ArgoCD SA, which carries the full gitops-openstack ClusterRole. Each Job only needs a narrow slice of that privilege:

  - approve-installplan: get/list/patch installplans in openstack-operators
  - controlplane post-delete hook: delete openstackcontrolplanes in openstack
  - dataplane post-delete hook: delete openstackdataplaneservices in openstack
  - observability post-delete hook: delete CSVs in openshift-operators

Add inline comments on each serviceAccountName field documenting the FIND-013 design recommendation: create a dedicated SA per Job with a minimal Role/ClusterRole and automountServiceAccountToken: true only on the Job pod spec.

The approve-installplan Job is a CI/lab convenience for Manual installPlanApproval and will become unnecessary with OLM v2 (ClusterExtension API). The post-delete hooks are example patterns not intended for production use as-is.

Addressed as informational: the excess privilege originates in FIND-001 (gitops-openstack ClusterRole scope); this finding tracks the least-privilege design recommendation for Job SAs.