### PR TITLE
fix(annotations): remove openshift-nmstate PSA audit/warn patches

### DIFF
--- a/components/argocd/annotations/kustomization.yaml
+++ b/components/argocd/annotations/kustomization.yaml
@@ -95,19 +95,6 @@ patches:
           pod-security.kubernetes.io/warn-version: latest
   - target:
       kind: Namespace
-      name: openshift-nmstate
-    patch: |-
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-nmstate
-        labels:
-          pod-security.kubernetes.io/audit: restricted
-          pod-security.kubernetes.io/audit-version: latest
-          pod-security.kubernetes.io/warn: restricted
-          pod-security.kubernetes.io/warn-version: latest
-  - target:
-      kind: Namespace
       name: cert-manager-operator
     patch: |-
       apiVersion: v1


### PR DESCRIPTION
Remove the pod-security.kubernetes.io/audit and /warn strategic merge patches for Namespace/openshift-nmstate from the annotations component.

These patches set audit: restricted and warn: restricted on the openshift-nmstate namespace at sync-wave -30. However, OLM overrides both labels to "privileged" when it installs the NMState operator at sync-wave -10, because the nmstate-handler DaemonSet runs privileged workloads on all nodes. This override happens despite security.openshift.io/scc.podSecurityLabelSync being set to "false" on the namespace.

The result is a permanent OutOfSync in the operator-dependencies ArgoCD application: ArgoCD applies restricted, OLM overwrites to privileged, ArgoCD detects drift, re-applies restricted, and the cycle repeats on every reconciliation.

The upstream architecture source (openstack-k8s-operators/architecture lib/olm-deps/nmstate_namespace.yaml) intentionally sets only enforce: privileged and does not specify audit or warn labels, correctly deferring those to the platform. The annotations component was adding values that conflict with the operator's actual security profile.

Removing this patch lets OLM set the PSA labels to match the workload's actual security requirements, eliminating the drift.

The other PSA patches (openstack, openstack-operators, metallb-system, cert-manager-operator) are not affected — they are retained because those namespaces do not exhibit the same OLM-driven override behavior.