### PR TITLE
fix(eso): remove targetNamespaces from OperatorGroup spec

### DIFF
--- a/components/secrets/external-secrets-operator/redhat/operatorgroup.yaml
+++ b/components/secrets/external-secrets-operator/redhat/operatorgroup.yaml
@@ -4,5 +4,4 @@ kind: OperatorGroup
 metadata:
   name: openshift-external-secrets-operator
   namespace: external-secrets-operator
-spec:
-  targetNamespaces: []
+spec: {}


### PR DESCRIPTION
Remove the explicit `targetNamespaces: []` from the
openshift-external-secrets-operator OperatorGroup and leave the spec
empty (`spec: {}`).

An OperatorGroup with `targetNamespaces: []` and one with an empty
spec both configure AllNamespaces install mode — they are semantically
identical. However, OLM normalizes the OperatorGroup on every
reconciliation cycle: it strips `targetNamespaces: []` from the spec
entirely and replaces it with `{"upgradeStrategy": "Default"}`.

This creates permanent drift in the operator-dependencies ArgoCD
application:

  - ArgoCD applies the manifest with `targetNamespaces: []`
  - OLM reconciles and removes the field
  - ArgoCD detects the diff (`> targetNamespaces: []` present in
    desired but absent in live) and marks the resource OutOfSync
  - Auto-sync re-applies, OLM re-normalizes, and the cycle repeats

By omitting the field from the source manifest, the desired state
matches what OLM produces after normalization, eliminating the
persistent OutOfSync condition.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
