### PR TITLE
fix(approve-installplan): use dedicated SA instead of ArgoCD 

### DIFF
--- a/components/utilities/approve-installplan/job.yaml
+++ b/components/utilities/approve-installplan/job.yaml
@@ -235,13 +235,4 @@ spec:
 
               log "Job completed successfully."
       restartPolicy: Never
-      # NOTE (FIND-013 / OSPRH-32425): This Job runs as the shared ArgoCD SA which
-      # carries the full gitops-openstack ClusterRole. The approve-installplan pattern
-      # is a CI/lab convenience to handle Manual installPlanApproval without human
-      # intervention; it is not intended for production environments. When OLM v2
-      # (ClusterExtension API) becomes standard, InstallPlan approval is replaced by
-      # version pinning in Git and this Job will no longer be needed. For production
-      # use, create a dedicated SA bound only to a Role granting get/list/patch on
-      # installplans in the target namespace, with automountServiceAccountToken: true
-      # only on the Job pod spec.
-      serviceAccountName: openshift-gitops-argocd-application-controller
+      serviceAccountName: installplan-approver

--- a/components/utilities/approve-installplan/job.yaml
+++ b/components/utilities/approve-installplan/job.yaml
@@ -217,6 +217,25 @@ spec:
 
               # --- Main execution ---
               log "Starting install_plan_approval"
+
+              # Short-circuit: if the pinned CSV is already installed, there is
+              # no pending InstallPlan to approve. An upgrade plan for a newer
+              # version may exist but we intentionally ignore it (version-gated).
+              pinned_csv=$(oc get subscription "${SUBSCRIPTION_NAME}" \
+                -n "${OS_OPERATORS_NAMESPACE}" \
+                -o jsonpath='{.spec.startingCSV}' 2>/dev/null) || true
+              if [ -n "$pinned_csv" ]; then
+                csv_phase=$(oc get csv "${pinned_csv}" \
+                  -n "${OS_OPERATORS_NAMESPACE}" \
+                  -o jsonpath='{.status.phase}' 2>/dev/null) || true
+                if [ "${csv_phase}" = "Succeeded" ]; then
+                  log "CSV ${pinned_csv} is already installed (phase: Succeeded). Skipping InstallPlan approval."
+                  wait_for_crd
+                  log "Job completed successfully."
+                  exit 0
+                fi
+              fi
+
               install_plan_name=$(find_and_approve_installplan)
 
               log "Waiting for InstallPlan '$install_plan_name' to complete..."

--- a/components/utilities/approve-installplan/rbac.yaml
+++ b/components/utilities/approve-installplan/rbac.yaml
@@ -2,7 +2,7 @@
 # Dedicated ServiceAccount for the approve-installplan Job.
 # Using a dedicated SA instead of the ArgoCD application controller SA makes
 # the component self-contained and VP-compatible: in Validated Patterns the
-# ArgoCD instance lives in rhoso-gitops-standalone, not openshift-gitops, so
+# ArgoCD instance lives in vp-gitops, not openshift-gitops, so
 # openshift-gitops-argocd-application-controller never exists there.
 apiVersion: v1
 kind: ServiceAccount
@@ -29,6 +29,7 @@ rules:
       - operators.coreos.com
     resources:
       - subscriptions
+      - clusterserviceversions
     verbs:
       - get
       - list

--- a/components/utilities/approve-installplan/rbac.yaml
+++ b/components/utilities/approve-installplan/rbac.yaml
@@ -1,5 +1,16 @@
 ---
-# ClusterRole and binding so the OpenShift GitOps Argo CD application controller
+# Dedicated ServiceAccount for the approve-installplan Job.
+# Using a dedicated SA instead of the ArgoCD application controller SA makes
+# the component self-contained and VP-compatible: in Validated Patterns the
+# ArgoCD instance lives in rhoso-gitops-standalone, not openshift-gitops, so
+# openshift-gitops-argocd-application-controller never exists there.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: installplan-approver
+  namespace: openshift-gitops
+---
+# ClusterRole and binding so the installplan-approver ServiceAccount
 # can approve OLM InstallPlans and read resources used by the approval Job.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -47,5 +58,5 @@ roleRef:
   name: installplan-approver-role
 subjects:
   - kind: ServiceAccount
-    name: openshift-gitops-argocd-application-controller
+    name: installplan-approver
     namespace: openshift-gitops


### PR DESCRIPTION
## Summary

The `approve-openstack-installplan` Job in `components/utilities/approve-installplan/` previously used `serviceAccountName: openshift-gitops-argocd-application-controller` in the `openshift-gitops` namespace. In Validated Patterns (VP) deployments, ArgoCD runs in a dedicated namespace (`rhoso-gitops-standalone`), so `openshift-gitops-argocd-application-controller` never exists in `openshift-gitops` — causing the Job pod to fail with `FailedCreate` in a loop indefinitely.

## Changes

**`components/utilities/approve-installplan/rbac.yaml`**
- Add dedicated `ServiceAccount: installplan-approver` in `openshift-gitops` namespace
- Update `ClusterRoleBinding` subject from `openshift-gitops-argocd-application-controller` to `installplan-approver`
- Add `clusterserviceversions` to the ClusterRole rules (required for the idempotency check)

**`components/utilities/approve-installplan/job.yaml`**
- Update `serviceAccountName` to `installplan-approver`
- Add short-circuit: if the pinned CSV is already in `Succeeded` phase, exit 0 immediately — handles re-runs where the operator is already installed but OLM has created an upgrade InstallPlan for a newer version

## Why a dedicated SA

The original design borrowed the ArgoCD application controller SA because it already had broad cluster access. In VP deployments this SA does not exist in `openshift-gitops`. A dedicated SA with only the permissions the Job actually needs is more correct regardless of deployment model:
- Works in both standard GitOps and VP deployments
- Follows least-privilege principle
- Makes the component self-contained

## Testing

Validated in a VP CI pipeline (`doc-extracted-vp`) on OCP 4.18 with `openstack-operator.v1.0.16`:
- Job pod created successfully with `installplan-approver` SA ✅
- InstallPlan approved, operator installed, CRDs registered ✅
- Re-run idempotency: short-circuit exits 0 when CSV already `Succeeded` ✅
- Version-gating: correctly refuses to approve upgrade plan for `v1.21.0` when pinned to `v1.0.16` ✅

Jira: OSPRH-32069